### PR TITLE
mark vars as dynamic to supress _constant_ warnings

### DIFF
--- a/src/confs/core.clj
+++ b/src/confs/core.clj
@@ -4,8 +4,8 @@
             [clojure.set :as set]
             [clojure.java.io :as io]))
 
-(def *conf* nil)
-(def *paths* nil)
+(def ^:dynamic *conf* nil)
+(def ^:dynamic *paths* nil)
 
 (defmacro conf
   [& ks]
@@ -70,6 +70,6 @@
         confs (mapv #(edn/read-string (slurp (or (io/resource %) %)))
                     paths)]
     (-validate confs)
-    (def *conf* (apply -deep-merge (reverse confs)))
-    (def *paths* paths)
+    (def ^:dynamic *conf* (apply -deep-merge (reverse confs)))
+    (def ^:dynamic *paths* paths)
     nil))


### PR DESCRIPTION
this doesn't really fix what clojure is complaining about and has to do with the compiler optimizing everything to be non-dynamic by default. Just add the `^:dynamic` tag so we don't have to look at constant warnings in the repl/terminal

feelsbadman.jpg